### PR TITLE
fix: update theme count from 12 to 18

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -604,8 +604,8 @@
       <div class="section-header animate-on-scroll">
         <span class="section-tag">Themes</span>
         <h2 class="section-title">Find your <span class="gradient-text">aesthetic.</span></h2>
-        <p class="section-desc">12 handcrafted themes designed to make your page stand out. Switch anytime with one
-          click.</p>
+        <p class="section-desc">18 handcrafted themes designed to make your page stand out. Switch anytime with one
+  click.</p>
       </div>
 
       <div class="theme-showcase" id="themeShowcase">


### PR DESCRIPTION
## Fixes Issue #12

## Changes Made
- Changed theme count from `12` to `18` in the Themes section description
- Now accurately reflects the 18 theme cards displayed

## Before
"12 handcrafted themes..."

## After  
"18 handcrafted themes..."

## Testing
- [x] Verified 18 theme cards exist in theme-showcase
- [x] Text now matches actual count
- [x] No broken functionality



Ready for review! 🚀