### PR TITLE
docs: add .env.example and improve onboarding setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key
+JWT_SECRET=your-random-secret-min-32-chars

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Create a `.env` file in the root directory:
 
 **Linux / macOS:**
 ```bash
-cp .env.example .env # If available, otherwise create manually
+cp .env.example .env 
 nano .env
 ```
 


### PR DESCRIPTION
## Description
Added a `.env.example` file and improved the environment setup documentation to make local development and onboarding easier for contributors.

**Fixes #33**

## Changes Made
- Added `.env.example` with placeholder environment variables
- Improved README setup instructions for environment configuration
- Simplified contributor onboarding experience

## Screenshots

### Before
- No `.env.example` file available
- Contributors had to manually figure out required environment variables
<img width="545" height="43" alt="Screenshot 2026-05-22 at 11 45 09 AM" src="https://github.com/user-attachments/assets/238149eb-e5d6-41c0-a66a-f5d3b8ca0ca6" />

### After
- Added `.env.example` with all required variables
- Clearer setup instructions in README for local development
<img width="503" height="27" alt="Screenshot 2026-05-22 at 11 58 29 AM" src="https://github.com/user-attachments/assets/c74a4b82-c37b-47ad-a0e9-2917b89d583b" />


## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.