### PR TITLE
fix(team-page): elevate btn-apply z-index to resolve unclickable hover state issue

### DIFF
--- a/public/team.html
+++ b/public/team.html
@@ -200,6 +200,9 @@
       text-decoration: none; border: none; cursor: pointer;
       box-shadow: 0 8px 32px rgba(168,85,247,0.35);
       transition: all 0.3s cubic-bezier(0.16,1,0.3,1);
+      /* fix 'Apply Now' buttons in Team Page */
+      position: relative;
+      z-index: 2;
     }
     .btn-apply:hover {
       transform: translateY(-3px); box-shadow: 0 16px 48px rgba(168,85,247,0.5);


### PR DESCRIPTION
# Pull Request: Fix Unresponsive "Apply Now" Buttons on Team Page

## Description
This PR resolves the issue where the "Apply Now →" buttons inside the job cards on the `/team` page were completely unresponsive to user clicks (#40).

### What Happened
Initially, I planned to implement a smooth-scroll transition down to the general application block (Approach 1). However, while analyzing the codebase, I discovered that the contextual `mailto:` links with tailored subject lines (Approach 2) were already perfectly configured in the HTML by design! 

The real issue was a subtle layout stacking bug: the `.member-card::before` pseudo-element overlay (which handles the gradient background hover effect) was sitting directly on top of the interactive elements, intercepting and swallowing all mouse click events.

### Solution
Elevated the stacking context of the `.btn-apply` class by adding `position: relative;` and `z-index: 2;`. This allows the button to pierce through the absolute hover mask layer, restoring the intended functionality of the native mailto links perfectly without modifying any structural HTML.

---

## Code Diff Preview

### Before:
```css
.btn-apply {
  display: inline-flex; align-items: center; gap: 10px;
  background: linear-gradient(135deg, #a855f7, #ec4899);
  color: #fff; font-family: 'Outfit', sans-serif; font-weight: 700;
  font-size: 1rem; padding: 16px 40px; border-radius: 9999px;
  text-decoration: none; border: none; cursor: pointer;
  box-shadow: 0 8px 32px rgba(168,85,247,0.35);
  transition: all 0.3s cubic-bezier(0.16,1,0.3,1);
}
```

### After:
```css
.btn-apply {
  display: inline-flex; align-items: center; gap: 10px;
  background: linear-gradient(135deg, #a855f7, #ec4899);
  color: #fff; font-family: 'Outfit', sans-serif; font-weight: 700;
  font-size: 1rem; padding: 16px 40px; border-radius: 9999px;
  text-decoration: none; border: none; cursor: pointer;
  box-shadow: 0 8px 32px rgba(168,85,247,0.35);
  transition: all 0.3s cubic-bezier(0.16,1,0.3,1);
  /* fix 'Apply Now' buttons in Team Page */
  position: relative;
  z-index: 2;
}
```

## Type of Change 
- [x] Bug fix (non-breaking change which fixes an issue)

## Visual Verification
Below is a screen recording demonstrating the local fix, confirming that the buttons are now interactive and successfully trigger the mail client with the contextual subject lines:

### Before: 
<img width="800" height="513" alt="before-change" src="https://github.com/user-attachments/assets/49413869-734e-42d9-8098-a8bf0599a78b" />

### After:
<img width="800" height="513" alt="after-change" src="https://github.com/user-attachments/assets/b427df0d-da6c-4cf2-aaf8-231edd4870c2" />

Fixes #40 