### PR TITLE
fix:remove unnecessary theme card hover interaction

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -923,15 +923,11 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   overflow: hidden;
-  cursor: pointer;
+  cursor: default;
   transition: all var(--duration-normal) var(--ease-out);
 }
 
-.theme-preview-card:hover {
-  border-color: var(--accent);
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-glow);
-}
+
 
 .theme-swatch {
   height: 100px;


### PR DESCRIPTION
Fixes #52
Part of GSSoC 2026 contribution
## Changes Made
- Removed hover border highlight from landing page theme cards
- Removed translateY hover animation
- Removed glow shadow effect
- Theme cards now appear static and non-interactive on the public landing page

## Screenshots
- Before: Cards appeared clickable/interactable
<img width="2648" height="1076" alt="Image 24-05-26 at 4 52 PM" src="https://github.com/user-attachments/assets/87c0aa17-98ca-4c8b-9785-b4d31b44344a" />





- After: Cards remain static and no misleading interaction is shown
  
<img width="2516" height="1072" alt="Image 24-05-26 at 4 53 PM" src="https://github.com/user-attachments/assets/ae303eb7-9edc-4ee2-ac77-80caaabf2e94" />




## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.