### PR TITLE
fix: improve mega dropdown styling in light mode

### DIFF
--- a/public/css/light-mode.css
+++ b/public/css/light-mode.css
@@ -264,3 +264,9 @@
 :root.light-mode ::-webkit-scrollbar-track { background: #eaecf2; }
 :root.light-mode ::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.15); }
 :root.light-mode ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,0.25); }
+
+:root.light-mode .mega-dropdown-inner {
+  background: rgba(255,255,255,0.98);
+  border-color: rgba(0,0,0,0.07);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.12), 0 4px 20px rgba(0,0,0,0.06);
+}


### PR DESCRIPTION
# Fix Light Mode Mega Dropdown Styling

## Description
Fixed the mega dropdown appearance in light mode by improving the background visibility, border contrast, and shadow styling for a cleaner and more readable UI.

**Fixes #69 **

## Changes Made
- Improved mega dropdown background styling in light mode
- Added better border contrast for visibility
- Enhanced box shadow for cleaner depth and UI consistency

## Screenshots

### Before
<img width="1708" height="987" alt="Screenshot 2026-05-27 at 2 05 06 AM" src="https://github.com/user-attachments/assets/1a7a28c2-ead0-4972-9295-03ecd555255b" />


### After
<img width="1698" height="1034" alt="Screenshot 2026-05-27 at 2 01 06 AM" src="https://github.com/user-attachments/assets/c9541fdb-a29a-4bd6-bb17-9c5f377294f8" />


## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.

## Contribution Program
Contributing under GSSoC and NSOC.