### PR TITLE
Fix: Resolve sign-up page copy button clipboard issue

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -119,6 +119,58 @@
     });
   }
 
+  // ─── Copy Profile Link ───
+  function initCopyProfileBtn() {
+    const btn = document.getElementById('copyProfileBtn');
+    const preview = document.getElementById('usernamePreview');
+    if (!btn || !preview) return;
+
+    btn.addEventListener('click', async (e) => {
+      e.preventDefault();
+
+      // Get the username from the preview
+      const username = preview.textContent;
+      if (!username || username === 'your-username') {
+        showError('Please enter a username first.');
+        return;
+      }
+
+      // Construct the profile URL using current origin
+      const profileUrl = `${window.location.origin}/u/${username}`;
+
+      try {
+        // Try using the modern Clipboard API
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(profileUrl);
+        } else {
+          // Fallback for older browsers
+          const textarea = document.createElement('textarea');
+          textarea.value = profileUrl;
+          textarea.style.position = 'fixed';
+          textarea.style.opacity = '0';
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand('copy');
+          document.body.removeChild(textarea);
+        }
+
+        // Show "Copied!" feedback
+        const originalText = btn.textContent;
+        const originalBg = btn.style.background;
+        btn.textContent = 'Copied!';
+        btn.style.background = '#4ade80';
+
+        // Revert after 2 seconds
+        setTimeout(() => {
+          btn.textContent = originalText;
+          btn.style.background = originalBg;
+        }, 2000);
+      } catch (err) {
+        showError('Failed to copy. Please try again.');
+      }
+    });
+  }
+
   // ─── Signup ───
   function initSignup() {
     const form = document.getElementById('signupForm');
@@ -342,5 +394,6 @@
     initSignup();
     initUsernameCheck();
     initGoogleAuth();
+    initCopyProfileBtn();
   });
 })();


### PR DESCRIPTION
## Description
This PR fixes the clipboard copy bug on the sign-up page. When a user clicks the copy button next to their generated profile link, the system now successfully saves the URL to their clipboard and provides immediate visual feedback.

**Fixes #76**

## Changes Made
- Created a dedicated `initCopyProfileBtn` function inside `public/js/auth.js` to manage clipboard events.
- Structured the handler to fetch the username dynamically from `#usernamePreview` and build the absolute URL using `window.location.origin`.
- Implemented the modern `navigator.clipboard.writeText` API with an invisible `textarea` fallback (`document.execCommand('copy')`) for older browsers.
- Added instant UI feedback changing the button text to "Copied!" and changing the background color to green (`#4ade80`), which automatically reverts back after 2 seconds.
- Initialized `initCopyProfileBtn()` within the DOM lifecycle initialization block.

## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.