### PR TITLE
Feat: Added Real-time character counter for SEO meta description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -564,7 +564,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/public/admin.html
+++ b/public/admin.html
@@ -221,6 +221,9 @@
             <div class="form-group full">
               <label class="form-label">Meta Description (SEO)</label>
               <textarea class="form-input" id="settingMetaDesc" placeholder="Description for search engines..." rows="2"></textarea>
+              <div class="char-counter" id="metaDescCounter">
+                <span class="char-count">0</span> / 160 characters
+              </div>
             </div>
           </div>
         </div>

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -511,6 +511,29 @@ textarea.form-input {
   min-height: 80px;
 }
 
+/* ─── Character Counter ─── */
+.char-counter {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.char-counter .char-count {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.char-counter.warning {
+  color: var(--text-danger, #ef4444);
+}
+
+.char-counter.warning .char-count {
+  color: var(--text-danger, #ef4444);
+  font-weight: 700;
+}
+
 /* ─── Modal ─── */
 .modal-overlay {
   position: fixed;

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -862,10 +862,33 @@
       document.getElementById('settingVerifiedBadge').checked = settings.showVerifiedBadge !== false;
       document.getElementById('settingShowFooter').checked = settings.showFooter !== false;
       document.getElementById('settingCustomCSS').value = settings.customCSS || '';
+      // Initialize character counter on load
+      updateMetaDescCounter();
     } catch (err) {
       showToast('Failed to load settings', 'error');
     }
   }
+
+  // ═══════════ CHARACTER COUNTER FOR META DESCRIPTION ═══════════
+  function updateMetaDescCounter() {
+    const textarea = document.getElementById('settingMetaDesc');
+    const counter = document.getElementById('metaDescCounter');
+    const charCount = counter.querySelector('.char-count');
+    const length = textarea.value.length;
+    const maxLength = 160;
+
+    charCount.textContent = length;
+    
+    // Add warning class when exceeding max length
+    if (length > maxLength) {
+      counter.classList.add('warning');
+    } else {
+      counter.classList.remove('warning');
+    }
+  }
+
+  // Add real-time listener to meta description textarea
+  document.getElementById('settingMetaDesc').addEventListener('input', updateMetaDescCounter);
 
   document.getElementById('saveSettingsBtn').addEventListener('click', async () => {
     const data = {


### PR DESCRIPTION
## Description
This PR introduces a real-time character counter for the SEO Meta Description textarea field under Page Settings in the Admin Dashboard. It ensures that administrators have a live character count while typing to assist them in optimizing their text snippet boundaries before search engine truncation kicks in.

**Fixes #77**

## Changes Made
- **HTML (`public/admin.html`)**: Added a character counter structure (`#metaDescCounter` and `.char-count`) directly underneath the `settingMetaDesc` textarea in the Page Settings block.
- **CSS (`public/css/admin.css`)**: Styled the character counter components with dynamic transitions and integrated a `.warning` modifier to alert users with a danger color (`#ef4444`) once they exceed the 160-character threshold.
- **JavaScript (`public/js/admin.js`)**: 
  - Implemented the `updateMetaDescCounter()` routine to dynamically calculate input string length and toggle warning states.
  - Attached an `input` event listener to the textarea for instant state updates.
  - Hooked the routine into the configuration payload initialization to ensure the current counter updates immediately upon loading settings.

## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.