### PR TITLE
(fix): initialize googleClient OAuth2Client instance before use

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,6 +22,11 @@ if (!process.env.JWT_SECRET) {
 }
 const JWT_SECRET = process.env.JWT_SECRET;
 
+// Google OAuth client (only initialized if GOOGLE_CLIENT_ID is set)
+let googleClient = null;
+if (process.env.GOOGLE_CLIENT_ID) {
+  googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+}
 
 //LOGIN limiter
 const loginLimiter = rateLimit({
@@ -499,6 +504,10 @@ app.get('/api/auth/google-client-id', (req, res) => {
 
 app.post('/api/auth/google', googleAuthLimiter, async (req, res) => {
   try {
+    if (!process.env.GOOGLE_CLIENT_ID || !googleClient) {
+      return res.status(503).json({ error: 'Google authentication is not configured.' });
+    }
+
     const { credential, access_token } = req.body;
     let payload;
 


### PR DESCRIPTION
## Description
`googleClient` was imported but never instantiated (`new OAuth2Client(...)`), so any Google OAuth request would throw a `ReferenceError` at runtime. This fix initializes the client when `GOOGLE_CLIENT_ID` is configured and adds a guard to return a clear error when it's not configured.
## Changes
- **server.js**: Initialize `googleClient` OAuth2Client instance after JWT_SECRET check
- **server.js**: Add guard to return 503 if Google OAuth is not configured
## Details
The existing frontend flow (Google GSI SDK in `login.html`/`signup.html`, token exchange in `auth.js`) was already correctly implemented — only the backend initialization was missing.

closes #70 , @mayo-byte07 , please approve this PR , thnx.