### PR TITLE
fix(auth): initialize googleClient for Google OAuth verification

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const cookieParser = require('cookie-parser');
 const crypto = require('crypto');
 const supabase = require('./db');
 const { OAuth2Client } = require('google-auth-library');
+const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const rateLimit = require('express-rate-limit');
 const app = express();
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Description

Fixes #114 

This PR fixes a runtime error occurring during Google OAuth authentication where `googleClient` was referenced before being initialized in `server.js`.

The issue caused the `/api/auth/google` endpoint to fail with:

```bash
ReferenceError: googleClient is not defined
```

The fix initializes `googleClient` using `OAuth2Client` and the configured `GOOGLE_CLIENT_ID` environment variable.

## Changes Made

<!-- List the specific changes you made here -->

* Added initialization for `googleClient` in `server.js`
* Configured `OAuth2Client` using `process.env.GOOGLE_CLIENT_ID`
* Fixed Google OAuth token verification flow
* Validated server syntax using `node -c server.js`

## Screenshots (if applicable)

<!-- Attach before and after screenshots of the working feature or UI changes here. Drag and drop works perfectly. -->

N/A

## Checklist

<!-- Check these boxes before submitting your PR -->

* [x] I have linked the relevant issue above.
* [x] I have tested my changes locally.
* [x] My code follows the project's style guidelines.
