### PR TITLE
fix: center-align footer column text

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -1441,6 +1441,11 @@
   display: flex;
   gap: 60px;
   margin-bottom: 32px;
+  justify-content: center;
+}
+
+.footer-links-grid > div {
+  text-align: center;
 }
 
 .footer-links-grid h4 {


### PR DESCRIPTION
## Description

The footer section columns (Product, Get Started, Support) were left-aligned. Added \justify-content: center\ to the footer grid and \	ext-align: center\ to each column so the footer content is properly centered across all screen sizes.

Closes #95

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings