### PR TITLE
fix: reload live preview iframe on category deletion

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -308,6 +308,7 @@
           showToast('Category deleted');
           await loadCategories();
           await loadLinks();
+          reloadPreview();
         } catch (err) {
           showToast('Failed to delete category', 'error');
         }


### PR DESCRIPTION
## Description
This pull request fixes the stale Live Preview mockup bug on the Admin Dashboard. When a user deletes a category, the preview iframe now automatically refreshes in real-time, removing the deleted category and its associated links without requiring a manual page reload.

## closes #181

## Changes Made
- Added a call to `reloadPreview()` inside the successful `try` block of the category deletion click handler in [admin.js](file:///c:/Users/tejj1/OneDrive/Desktop/New%20folder%20%282%29/New%20folder%20%285%29/public/js/admin.js).
- This ensures that when a category is deleted, the preview mockup screen reloads automatically to stay in sync with the updated database state.

## Screenshots (if applicable)
<img width="1437" height="783" alt="image" src="https://github.com/user-attachments/assets/fa226bff-acf1-466f-9457-1b4922281ef0" />


## Checklist
- [x] I have linked the relevant issue above (or described it fully).
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.
