### PR TITLE
fix: update theme count references to 26

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -398,7 +398,7 @@
       </h1>
       <p class="hero-subtitle animate-on-scroll">
         <span id="typewriter"></span><span class="typewriter-cursor">|</span><br>
-        <span style="opacity: 0.8; font-size: 0.95rem;">Choose from 12+ stunning themes, track analytics, and make your online presence unforgettable.</span>
+        <span style="opacity: 0.8; font-size: 0.95rem;">Choose from 26+ stunning themes, track analytics, and make your online presence unforgettable.</span>
       </p>
       <div class="hero-cta animate-on-scroll">
         <a href="/admin" class="btn-hero btn-hero-primary">
@@ -541,7 +541,7 @@
               <polyline points="21 15 16 10 5 21" />
             </svg>
           </div>
-          <h3>12+ Stunning Themes</h3>
+          <h3>26+ Stunning Themes</h3>
           <p>From Midnight Noir to Neon Cyber — find the perfect aesthetic that matches your vibe. One click to switch.
           </p>
         </div>
@@ -618,7 +618,7 @@
       <div class="section-header animate-on-scroll">
         <span class="section-tag">Themes</span>
         <h2 class="section-title">Find your <span class="gradient-text">aesthetic.</span></h2>
-        <p class="section-desc">18 handcrafted themes designed to make your page stand out. Switch anytime with one
+        <p class="section-desc">26 handcrafted themes designed to make your page stand out. Switch anytime with one
   click.</p>
       </div>
 
@@ -869,7 +869,7 @@
       </div>
       <div class="stats-row">
         <div class="stat-block animate-on-scroll">
-          <div class="stat-number" data-target="12">0</div>
+          <div class="stat-number" data-target="26">0</div>
           <div class="stat-label-text">Themes</div>
         </div>
         <div class="stat-block animate-on-scroll">


### PR DESCRIPTION
## Description

Updated the theme count references on the landing page to match the actual number of themes defined in `admin.js`.

Fixes #180

## Changes Made

- Updated "12+ stunning themes" to "26+ stunning themes"
- Updated "18 handcrafted themes" to "26 handcrafted themes"
- Updated stats counter from `12` to `26`

## Screenshots

N/A

## Checklist

- [x] I have linked the relevant issue above.
- [ ] I have tested my changes locally.
- [x] My code follows the project's style guidelines.
