### PR TITLE
Eye button added in sign in section

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -805,4 +805,40 @@ input, textarea, select {
     padding: 0.5rem 0;
   }
 }
+.password-wrapper{
+    position: relative;
+}
+
+.password-wrapper .form-input{
+    padding-right: 52px;
+}
+
+.toggle-password{
+    position:absolute;
+    right:14px;
+    top:50%;
+    transform:translateY(-50%);
+    border:none;
+    background:transparent;
+    cursor:pointer;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    color:#8b8b8b;
+    transition:.25s ease;
+    padding:4px;
+}
+
+.toggle-password:hover{
+    color:#ffffff;
+    transform:translateY(-50%) scale(1.08);
+}
+
+.light-mode .toggle-password:hover{
+    color:#111827;
+}
+
+.toggle-password svg{
+    transition:.2s;
+}
 

--- a/public/login.html
+++ b/public/login.html
@@ -47,8 +47,49 @@
         </div>
         <div class="form-group">
           <label class="form-label">Password</label>
-          <input class="form-input" type="password" id="loginPassword" placeholder="••••••••" required>
-        </div>
+
+          <div class="password-wrapper"><input class="form-input" type="password" id="loginPassword" placeholder="••••••••" required>
+    <button
+      type="button"
+      class="toggle-password"
+      id="togglePassword"
+      aria-label="Show password"
+    >
+      <!-- Eye Icon -->
+      <svg id="eyeOpen" xmlns="http://www.w3.org/2000/svg"
+        width="20" height="20" fill="none"
+        viewBox="0 0 24 24" stroke="currentColor"
+        stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M2.458 12C3.732 7.943 7.523 5 12 5
+          c4.478 0 8.268 2.943 9.542 7
+          -1.274 4.057-5.064 7-9.542 7
+          -4.477 0-8.268-2.943-9.542-7z"/>
+        <circle cx="12" cy="12" r="3"/>
+      </svg>
+
+      <!-- Eye Off Icon -->
+      <svg id="eyeClosed" xmlns="http://www.w3.org/2000/svg"
+        width="20" height="20" fill="none"
+        viewBox="0 0 24 24" stroke="currentColor"
+        stroke-width="2" style="display:none;">
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M3 3l18 18"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M10.584 10.587A2 2 0 0012 14
+          a2 2 0 001.414-.586"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M9.88 5.09A9.77 9.77 0 0112 5
+          c4.477 0 8.268 2.943 9.542 7
+          a9.956 9.956 0 01-4.293 5.175"/>
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M6.228 6.228A9.956 9.956 0 002.458 12
+          c1.274 4.057 5.065 7 9.542 7
+          a9.77 9.77 0 003.182-.527"/>
+      </svg>
+    </button>
+  </div>
+</div>
         <button type="submit" class="auth-submit">
           <span class="btn-content">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -85,5 +126,27 @@
 
   <script src="/js/auth.js"></script>
   <script src="js/theme-toggle.js"></script>
+
+  <script>
+    const password = document.getElementById("loginPassword");
+    const toggle = document.getElementById("togglePassword");
+    const eyeOpen = document.getElementById("eyeOpen");
+    const eyeClosed = document.getElementById("eyeClosed");
+
+    toggle.addEventListener("click", () => {
+        if (password.type === "password") {
+            password.type = "text";
+            eyeOpen.style.display = "none";
+            eyeClosed.style.display = "block";
+            toggle.setAttribute("aria-label", "Hide password");
+        } else {
+            password.type = "password";
+            eyeOpen.style.display = "block";
+            eyeClosed.style.display = "none";
+            toggle.setAttribute("aria-label", "Show password");
+        }
+    });
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Description
Added a modern password visibility (eye toggle) feature to the authentication pages, allowing users to show or hide their password while typing for a better user experience.

**Fixes #116**

## Changes Made
-Added a modern eye toggle button to the Login password field.
-Added the same eye toggle functionality to the Signup password fields.
-Implemented JavaScript to switch between hidden and visible password states.
-Styled the toggle button to match the existing UI and ensure a clean, responsive design.

## Screenshots (if applicable)

Before
<img width="1366" height="768" alt="Screenshot (1479)" src="https://github.com/user-attachments/assets/1171899f-8fc7-435a-a8d4-4a9ce2255aac" />

After
<img width="1366" height="768" alt="Screenshot (1480)" src="https://github.com/user-attachments/assets/19248157-526c-432b-955d-e4deb77321dd" />
<img width="1366" height="768" alt="Screenshot (1481)" src="https://github.com/user-attachments/assets/b3efe11f-dda2-449a-ba8b-750fc2e5c3ed" />


## Checklist
<!-- Check these boxes before submitting your PR -->
- [ ] I have linked the relevant issue above.
- [ ] I have tested my changes locally.
- [ ] My code follows the project's style guidelines.
