### PR TITLE
fix: sanitize custom CSS to prevent injection into public profile pages

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -93,10 +93,15 @@
       const footer = document.getElementById('pageFooter');
       if (footer && settings.showFooter === false) footer.style.display = 'none';
 
-      // Custom CSS
+      // Custom CSS (client-side sanitization as defense-in-depth)
       if (settings.customCSS) {
         const style = document.createElement('style');
-        style.textContent = settings.customCSS;
+        style.textContent = settings.customCSS
+          .replace(/url\s*\([^)]*\)/gi, '/* url() removed */')
+          .replace(/expression\s*\([^)]*\)/gi, '')
+          .replace(/behavior\s*:\s*[^;]+;?/gi, '')
+          .replace(/-moz-binding\s*:\s*[^;]+;?/gi, '')
+          .replace(/javascript\s*:/gi, '');
         document.head.appendChild(style);
       }
     } catch (err) {

--- a/server.js
+++ b/server.js
@@ -1303,6 +1303,19 @@ app.get('/api/settings', requireAuth, async (req, res) => {
   });
 });
 
+// ─── CSS Sanitization ───
+function sanitizeCSS(css) {
+  if (!css) return '';
+  // Strip potentially dangerous patterns
+  return css
+    .replace(/url\s*\([^)]*\)/gi, '/* url() removed */')
+    .replace(/expression\s*\([^)]*\)/gi, '')
+    .replace(/@import\s+url/gi, '@import') // neuter @import url()
+    .replace(/behavior\s*:\s*[^;]+;?/gi, '')
+    .replace(/-moz-binding\s*:\s*[^;]+;?/gi, '')
+    .replace(/javascript\s*:/gi, '');
+}
+
 app.put('/api/settings', requireAuth, async (req, res) => {
   const { data: current } = await supabase
     .from('user_settings')
@@ -1316,7 +1329,7 @@ app.put('/api/settings', requireAuth, async (req, res) => {
     meta_description: req.body.metaDescription ?? current?.meta_description ?? '',
     show_verified_badge: req.body.showVerifiedBadge ?? current?.show_verified_badge ?? false,
     show_footer: req.body.showFooter ?? current?.show_footer ?? true,
-    custom_css: req.body.customCSS ?? current?.custom_css ?? '',
+    custom_css: sanitizeCSS(req.body.customCSS ?? current?.custom_css ?? ''),
     selected_theme: req.body.selectedTheme ?? current?.selected_theme ?? 'midnight'
   };
 


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where unsanitized custom CSS could be used for UI redressing or data exfiltration against visitors of public profile pages.

### Vulnerability
Custom CSS entered by users via settings was stored and served verbatim to profile pages. Malicious CSS with \url()\ calls could exfiltrate data, and other dangerous properties could be used for UI redressing.

### Changes
- Added \sanitizeCSS()\ server-side function that strips dangerous patterns:
  - \url()\ — can be used for data exfiltration via background-image URLs
  - \expression()\ — IE-specific CSS expressions
  - \ehavior:\ — IE-specific behavior URLs
  - \-moz-binding\ — Firefox XBL binding URLs
  - \javascript:\ URLs
- Applied sanitization at the save settings endpoint (PUT /api/settings)
- Added defense-in-depth client-side sanitization in app.js when injecting CSS into the DOM

### Testing
- [ ] Custom CSS with \url()\ is sanitized (replaced with comment)
- [ ] Normal CSS properties (color, font-size, etc.) pass through unchanged
- [ ] Settings save and load correctly with sanitized CSS

Closes #140