### PR TITLE
fix: add maximum length validation for link titles

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -348,7 +348,7 @@
       </div>
       <div class="form-group">
         <label class="form-label">Title</label>
-        <input class="form-input" type="text" id="modalLinkTitle" placeholder="🚀 My Awesome Link">
+        <input class="form-input" type="text" id="modalLinkTitle" placeholder="🚀 My Awesome Link" maxlength="100">
       </div>
       <div class="form-group">
         <label class="form-label">URL</label>

--- a/server.js
+++ b/server.js
@@ -1016,6 +1016,12 @@ app.post('/api/links', requireAuth, async (req, res) => {
     return res.status(400).json({ error: 'End date must be after start date.' });
   }
 
+  // Validate title length
+ const title = (req.body.title || 'New Link').trim();
+ if (title.length > 100) {
+  return res.status(400).json({ error: 'Link title must be 100 characters or fewer.' });
+}
+
   // Handle category assignment
   let categoryId = req.body.category_id ?? null;
   if (categoryId === 'uncategorized' || categoryId === '') categoryId = null;
@@ -1024,7 +1030,7 @@ app.post('/api/links', requireAuth, async (req, res) => {
   const { error } = await supabase.from('user_links').insert({
     id: newLinkId,
     user_id: req.auth.userId,
-    title: req.body.title || 'New Link',
+    title,
     url: req.body.url || 'https://',
     icon: req.body.icon || 'link',
     clicks: 0,
@@ -1044,7 +1050,7 @@ app.post('/api/links', requireAuth, async (req, res) => {
 
   res.status(201).json({
     id: newLinkId,
-    title: req.body.title || 'New Link',
+    title,
     url: req.body.url || 'https://',
     icon: req.body.icon || 'link',
     clicks: 0,
@@ -1141,7 +1147,13 @@ app.put('/api/links/:id', requireAuth, async (req, res) => {
   if (!existing) return res.status(404).json({ error: 'Link not found' });
 
   const updates = {};
-  if (req.body.title !== undefined) updates.title = req.body.title;
+  if (req.body.title !== undefined) {
+  const title = req.body.title.trim();
+  if (title.length > 100) {
+    return res.status(400).json({ error: 'Link title must be 100 characters or fewer.' });
+  }
+  updates.title = title;
+  }
   if (req.body.url !== undefined) updates.url = req.body.url;
   if (req.body.icon !== undefined) updates.icon = req.body.icon;
   if (req.body.active !== undefined) updates.active = req.body.active;


### PR DESCRIPTION
## Description

Fixes #136

## Changes Made

* Added backend validation in `POST /api/links` to reject titles longer than 100 characters
* Added backend validation in `PUT /api/links/:id` to enforce the same limit during updates
* Added `maxlength="100"` to the title input in `public/admin.html` to prevent invalid submissions from the frontend
* Returns a `400 Bad Request` response with a clear error message when the limit is exceeded

## Screenshots (if applicable)

N/A — validation-related change

## Checklist

* [x] I have linked the relevant issue above.
* [x] I have verified the validation logic.
* [x] My code follows the project's style guidelines.

