### PR TITLE
Fix: Restrict wildcard CORS to prevent CSRF vulnerability (#167)

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,7 +68,23 @@ const googleAuthLimiter = rateLimit({
 });
 
 // Middleware
-app.use(cors());
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map(o => o.trim())
+  .filter(Boolean);
+
+app.use(cors({
+  origin: (origin, callback) => {
+    // Allow same-origin (no Origin header) and whitelisted origins
+    if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+      return callback(null, true);
+    }
+    callback(new Error(`CORS: origin ${origin} not allowed`));
+  },
+  credentials: true,    // required for cookie-based auth
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+}));
 app.use(express.json());
 app.use(cookieParser());
 

--- a/tests/cors.test.js
+++ b/tests/cors.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+// Set env vars before requiring app
+process.env.ALLOWED_ORIGINS = 'http://allowed.com,http://another.com';
+process.env.JWT_SECRET = 'testsecret';
+process.env.SUPABASE_URL = 'http://localhost:8000';
+process.env.SUPABASE_SERVICE_KEY = 'dummykey';
+process.env.VERCEL = '1';
+
+const app = require('../server');
+
+test('CORS Allowlist Test', async (t) => {
+  const server = http.createServer(app);
+  
+  await new Promise((resolve) => {
+    server.listen(0, () => resolve());
+  });
+
+  const port = server.address().port;
+
+  await t.test('Allowed origin should succeed', async () => {
+    const res = await fetch(`http://localhost:${port}/api/auth/check`, {
+      method: 'OPTIONS',
+      headers: {
+        'Origin': 'http://allowed.com',
+        'Access-Control-Request-Method': 'POST'
+      }
+    });
+    
+    assert.strictEqual(res.status, 204);
+    assert.strictEqual(res.headers.get('access-control-allow-origin'), 'http://allowed.com');
+  });
+
+  await t.test('Disallowed origin should fail', async () => {
+    const res = await fetch(`http://localhost:${port}/api/auth/check`, {
+      method: 'OPTIONS',
+      headers: {
+        'Origin': 'http://evil.com',
+        'Access-Control-Request-Method': 'POST'
+      }
+    });
+    
+    // cors throws an error to the callback which express catches and returns 500
+    assert.strictEqual(res.status, 500);
+    assert.notStrictEqual(res.headers.get('access-control-allow-origin'), 'http://evil.com');
+  });
+
+  server.close();
+});


### PR DESCRIPTION
## Description
This PR addresses a Cross-Site Request Forgery (CSRF) vulnerability in the application by restricting the CORS configuration. Previously, the `cors()` middleware was used without an origin allowlist, setting `Access-Control-Allow-Origin: *` which enabled arbitrary sites to make credentialed requests to state-mutating endpoints. 

**Fixes #167**

## Changes Made
- Modified the `cors()` configuration in `server.js` to use an explicit allowlist pattern powered by the `ALLOWED_ORIGINS` environment variable.
- Enforced `credentials: true` alongside the origin check so cookie-based authentication operates safely without exposing endpoints to wildcard domains.
- Added a regression test suite (`tests/cors.test.js`) using Node's native test runner to verify that trusted origins are permitted while requests from untrusted origins are successfully blocked.

## Screenshots (if applicable)
*(Not applicable as this is a backend security fix)*

## Checklist
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.