### PR TITLE
Fix profile avatar overlap in live preview

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -780,6 +780,42 @@ select.form-input::-webkit-scrollbar-thumb {
   background: var(--bg-primary);
 }
 
+/* Live preview panel avatar visibility fix */
+.preview-panel,
+.preview-panel .phone-wrapper,
+.preview-panel .phone-mockup {
+  overflow: visible;
+}
+
+.preview-panel .phone-mockup {
+  padding-top: 10px;
+}
+
+.preview-panel .mock-avatar,
+.preview-panel .mock-avatar-circle,
+.preview-panel .mock-avatar-glow {
+  position: relative;
+  z-index: 60;
+}
+
+.preview-panel .mock-avatar,
+.preview-panel .mock-avatar-circle {
+  margin-top: 6px;
+}
+
+@media (max-width: 640px) {
+  .preview-panel .phone-mockup {
+    padding-top: 6px;
+  }
+
+  .preview-panel .mock-avatar,
+  .preview-panel .mock-avatar-circle {
+    width: 56px;
+    height: 56px;
+    margin-top: 4px;
+  }
+}
+
 /* ─── Empty State ─── */
 .empty-state {
   text-align: center;


### PR DESCRIPTION
## Description
Fixed the profile avatar overlap issue in the live preview section(#202)

## Changes Made
- Adjusted CSS positioning for avatar container
- Fixed overlapping layout issue in responsive view
- Improved UI alignment in preview mode

## Screenshots (if applicable)
-before fix
<img width="959" height="437" alt="Screenshot 2026-06-14 064707" src="https://github.com/user-attachments/assets/f4715f43-90b6-430d-bfd6-e9864cabc601" />

-after fix
<img width="951" height="430" alt="image" src="https://github.com/user-attachments/assets/9b6251e2-ed5e-4068-9c9f-caba9fbb75e6" />


## Checklist
<!-- Check these boxes before submitting your PR -->
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.
