### PR TITLE
added close button in sign in section

### DIFF
--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -337,4 +337,35 @@
 #passwordRequirements li.valid::before {
   content: '✓ ';
 }
+/* ─── Close Button ─── */
 
+.auth-card {
+  position: relative;
+}
+
+.close-btn {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 28px;
+  line-height: 38px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.close-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  transform: rotate(90deg);
+}
+
+.light-mode .close-btn:hover {
+  background: rgba(0, 0, 0, 0.08);
+}

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -477,5 +477,14 @@ btnLoader.style.display = 'inline';
     initUsernameCheck();
     initGoogleAuth();
     initCopyProfileBtn();
+    // Close button
+  const closeBtn = document.getElementById("closeBtn");
+
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => {
+      window.location.href = "/index.html";
+    });
+  }
+
   });
 })();

--- a/public/login.html
+++ b/public/login.html
@@ -25,6 +25,12 @@
   <div class="theme-toggle-floating"><button class="theme-toggle-btn" aria-label="Switch to light mode" title="Switch to light mode"><span class="toggle-track"><span class="toggle-icon toggle-icon-moon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></span><span class="toggle-icon toggle-icon-sun"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg></span><span class="toggle-thumb"></span></span></button></div>
   <div class="auth-page">
     <div class="auth-card">
+
+      <!-- Close Button -->
+  <button class="close-btn" id="closeBtn" aria-label="Close">
+    &times;
+  </button>
+  
       <div class="auth-header">
         <a href="/" class="auth-logo">
           <div class="logo-icon">


### PR DESCRIPTION
## Description
Added a **Close (✕) button** to the **Sign In** section.

**Fixes #213 **

## Changes Made

- Open Sign in section
-  Added a Close (✕) button to the Sign In page on the top of the right


## Screenshots (if applicable)

Before
<img width="1366" height="768" alt="Screenshot (1488)" src="https://github.com/user-attachments/assets/9a00a75f-7889-44e2-ab16-8eb569e00fe0" />


After
<img width="1366" height="768" alt="Screenshot (1489)" src="https://github.com/user-attachments/assets/c4402da1-84d3-4e62-9e43-b575fd5a85c2" />

## Checklist

- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.

