### PR TITLE
feat: add theme toggle in mobile and tablet view

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -2028,7 +2028,16 @@
 }
 
 @media (max-width: 768px) {
-  .navbar-links,
+  .navbar-links {
+    display: flex !important;
+    gap: 0;
+  }
+
+  .navbar-links > a,
+  .navbar-links > .nav-dropdown {
+    display: none !important;
+  }
+
   .navbar-actions,
   #navGuest,
   #navAuth {
@@ -2037,6 +2046,16 @@
 
   .mobile-menu-btn {
     display: flex;
+  }
+
+  .navbar-logo {
+    margin-right: auto !important;
+  }
+}
+
+@media (max-width: 375px) {
+  .logo-subtext {
+    display: none !important;
   }
 }
 

--- a/public/home.html
+++ b/public/home.html
@@ -135,8 +135,8 @@
         </div>
         <div style="display: flex; flex-direction: column; justify-content: center;">
           <span class="logo-text">Conn<span class="logo-dot">.</span></span>
-          <span
-            style="font-size: 0.5rem; color: var(--text-secondary); line-height: 1; margin-top: -1px; text-transform: uppercase; letter-spacing: 0.5px; opacity: 0.8;">powered
+          <span class="logo-subtext"
+            style="font-size: 0.5rem; color: var(--text-secondary); line-height: 1; margin-top: -1px; text-transform: uppercase; letter-spacing: 0.5px; opacity: 0.8; white-space: nowrap;">powered
             by aethercodesociety</span>
         </div>
       </a>

--- a/public/team.html
+++ b/public/team.html
@@ -220,7 +220,12 @@
 
     @media (max-width: 768px) {
       .team-nav { padding: 16px 20px; }
-      .team-nav-links { display: none; }
+      .team-nav-links { 
+        margin-left: auto;
+       }
+      .team-nav-links > a {
+        display: none !important;
+      }
       .team-hero { padding: 60px 20px 40px; }
       .team-stats { gap: 24px; flex-wrap: wrap; }
       .team-cta { padding: 40px 24px; }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. -->
Added a theme toggle in mobile and tablet view.
**Fixes #216**

⚠️ **Note**: The theme toggle will align perfectly when #283 is merged.

## Changes Made
<!-- List the specific changes you made here -->
**Global Stylesheet (`public/css/home.css`)**:
  - Kept `.navbar-links` container visible on screens $\le 768px$ but hid text links and dropdown elements inside it.
  - Hid the `.navbar-actions` container to prevent JavaScript inline style overrides.
  - Hid the logo subtext (`.logo-subtext`) on small screens ($\le 375px$) to free up horizontal space and prevent layout wrapping.
  
**Home Page (`public/home.html`)**:
  - Added target class `logo-subtext` and prevented wrapping on the logo subtext using `white-space: nowrap;`.
  
**Team Page (`public/team.html`)**:
  - Kept the container `.team-nav-links` visible and right-aligned, and hid only the text links, keeping the toggle button visible.


## Screenshots (if applicable)
<!-- Attach before and after screenshots of the working feature or UI changes here. Drag and drop works perfectly. -->
<img width="697" height="259" alt="Screenshot 2026-06-17 at 9 46 45 PM" src="https://github.com/user-attachments/assets/2aecd416-ec8f-4478-a151-ff5f74870b6e" />

<img width="699" height="224" alt="Screenshot 2026-06-21 at 12 15 14 AM" src="https://github.com/user-attachments/assets/19ddf23f-565a-4b6b-96bd-e156a2e03c2c" />

<img width="701" height="286" alt="Screenshot 2026-06-21 at 12 16 32 AM" src="https://github.com/user-attachments/assets/5b5c9183-ae4a-49e2-ae7d-95f72686408a" />

## Checklist
<!-- Check these boxes before submitting your PR -->
- [x] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.
