### PR TITLE
docs: add missing JWT errors troubleshooting content

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Verify that:
 - Database tables were created successfully
 
 ### JWT errors
+Ensure your `JWT_SECRET` is properly set in your `.env` file and is at least 32 characters long. If you recently changed your secret, all existing user sessions will be invalidated and users will need to log in again.
 
 ---
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. -->
This PR fixes an empty section under the `## 🛠 Troubleshooting` header in the README. The `### JWT errors` subheading was completely blank. I added a helpful troubleshooting step referencing the `.env` configuration (specifically `JWT_SECRET`).

**Fixes # None**

## Changes Made
<!-- List the specific changes you made here -->
- Added missing troubleshooting steps for the `### JWT errors` section.
- Clarified the `.env` requirements for `JWT_SECRET` to prevent session issues.

## Screenshots (if applicable)
<!-- Attach before and after screenshots of the working feature or UI changes here. Drag and drop works perfectly. -->
N/A

## Checklist
<!-- Check these boxes before submitting your PR -->
- [ ] I have linked the relevant issue above.
- [x] I have tested my changes locally.
- [x] My code follows the project's style guidelines.