### PR TITLE
fix(security): add sandbox + referrerpolicy to admin live-preview iframe

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -382,7 +382,7 @@
       <div class="phone-wrapper">
         <div class="phone-mockup">
           <div class="phone-notch"></div>
-          <iframe id="livePreviewIframe" class="preview-iframe" src="/me" title="Live Profile Preview"></iframe>
+          <iframe id="livePreviewIframe" class="preview-iframe" src="/me" title="Live Profile Preview" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer"></iframe>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
The admin live-preview iframe in `public/admin.html` loads `/me` without a `sandbox` attribute and without a `referrerpolicy`. A compromised profile (e.g. avatar/bio XSS or an external redirect from the previewed page) could escalate to the admin's authenticated session or leak the Referer.

## Changes
- Added `sandbox="allow-scripts allow-same-origin"` to `#livePreviewIframe`
- Added `referrerpolicy="no-referrer"`

## Reasoning
- `allow-scripts` is required so the live preview still renders JS-driven themes.
- `allow-same-origin` is needed for the preview to read authenticated profile data in the same origin; combined with `allow-scripts` it means the sandboxed frame is only as powerful as the origin itself, but it blocks navigation/form-submission/popups by default.
- `no-referrer` stops the admin's origin being sent to any cross-origin resources the previewed page pulls in.

Fixes #314