### PR TITLE
fix(security): instantiate googleClient before use in /api/auth/google

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,6 +26,10 @@ if (!process.env.GOOGLE_CLIENT_ID) {
   console.warn('  GOOGLE_CLIENT_ID not set — Google OAuth sign-in will be unavailable.');
 }
 
+// OAuth2Client is imported above but must be instantiated before use in
+// the Google token verification endpoint (/api/auth/google).
+const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+
 //LOGIN limiter
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
## Summary
`/api/auth/google` calls `googleClient.verifyIdToken(...)` at server.js:535, but `googleClient` is never declared anywhere in the file — Google sign-in is completely broken with `ReferenceError: googleClient is not defined`.

## Changes
- Instantiate `const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID)` once, immediately after the imports (server.js:31)

## Notes
- `OAuth2Client` is already imported at the top of the file.
- Safe when `GOOGLE_CLIENT_ID` is unset: the constructor does not throw; verification simply fails later, matching the existing warning block.

Fixes #315