### PR TITLE
fix(security): prevent stored XSS via unsanitized avatar URL

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -299,7 +299,9 @@ function applyTheme(themeName, isPreview = false) {
       // Avatar
       const avatarEl = document.getElementById('avatarEl');
       if (profile.avatar) {
-        avatarEl.innerHTML = `<img src="${profile.avatar}" alt="${profile.name}" />`;
+        // Escape both attributes — the stored avatar URL is user-controlled
+        // and must not be able to break out of the img tag (stored XSS).
+        avatarEl.innerHTML = `<img src="${escapeHtml(profile.avatar)}" alt="${escapeHtml(profile.name || '')}" />`;
       } else {
         const initials = (profile.name || 'C').charAt(0).toUpperCase();
         avatarEl.innerHTML = `<div class="avatar-placeholder">${initials}</div>`;

--- a/server.js
+++ b/server.js
@@ -713,11 +713,30 @@ app.put('/api/profile', requireAuth, async (req, res) => {
     }
   }
 
+  // Validate avatar URL before it is stored and served to every visitor of
+  // public profile pages. Reject non-http(s) schemes (javascript:, data:,
+  // vbscript:), malformed URLs, and characters that could break out of an
+  // HTML attribute — layered with client-side escaping to prevent stored XSS.
+  let avatar = (req.body.avatar ?? existing?.avatar ?? '').trim();
+  if (avatar) {
+    if (/[\s"'<>`]/.test(avatar) || !/^https?:\/\//i.test(avatar)) {
+      return res.status(400).json({ error: 'Avatar must be a valid http(s) URL' });
+    }
+    try {
+      const parsed = new URL(avatar);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return res.status(400).json({ error: 'Avatar must be a valid http(s) URL' });
+      }
+    } catch {
+      return res.status(400).json({ error: 'Avatar must be a valid URL' });
+    }
+  }
+
   const updates = {
     name: req.body.name ?? existing?.name ?? 'Your Name',
     bio: req.body.bio ?? existing?.bio ?? '',
     skills: req.body.skills ?? existing?.skills ?? '',
-    avatar: req.body.avatar ?? existing?.avatar ?? '',
+    avatar,
     interests: Array.isArray(req.body.interests) ? req.body.interests.filter(i => typeof i === 'string' && i.trim().length > 0) : (existing?.interests ?? []),
     socials
   };


### PR DESCRIPTION
## Summary
Stored XSS via avatar URL (`\u003cimg src="${profile.avatar}"\u003e` is interpolated unescaped into public profile pages). An attacker sets a `javascript:`/quote-breakout avatar via `PUT /api/profile`, and every visitor to the profile executes it.

## Changes
**Server (`server.js`, `PUT /api/profile`):**
- Validate avatar before storing: require an `http(s)` scheme and reject whitespace, quotes, angle brackets, and backticks so the stored value can never become valid HTML attribute syntax. Invalid values → `400`.

**Client (`public/js/app.js`):**
- Escape `src` and `alt` with the existing `escapeHtml()` when rendering the avatar.

## Testing
- 12 server-side URL validation cases pass (scheme attacks, quote/angle-bracket breakout, protocol-relative, malformed).
- Rendered avatar markup keeps exactly the `src`/`alt` delimiters for all payloads — no breakout possible.

## Note (pre-existing, out of scope)
`public/js/app.js` currently declares `let activeTheme` twice at top level (line 16 and 73) — a SyntaxError that breaks the whole file in browsers. That predates this PR; happy to address it in a follow-up if you'd like.

Fixes #308